### PR TITLE
Fixed NullPointerException

### DIFF
--- a/src/main/java/org/jboss/logging/LoggerProviders.java
+++ b/src/main/java/org/jboss/logging/LoggerProviders.java
@@ -147,7 +147,7 @@ final class LoggerProviders {
 
     private static void logProvider(final LoggerProvider provider, final String via) {
         // Log a debug message indicating which logger we are using
-        final Logger logger = provider.getLogger(LoggerProviders.class.getPackage().getName());
+        final Logger logger = provider.getLogger(LoggerProviders.class.getName());
         if (via == null) {
             logger.debugf("Logging Provider: %s", provider.getClass().getName());
         } else {


### PR DESCRIPTION
Fixed NullPointerException at line 150 because when executing outside a webserver the package being returned was null and it was causing a NullPointerException.